### PR TITLE
IPv4: Use `std` definition

### DIFF
--- a/src/credentials.rs
+++ b/src/credentials.rs
@@ -1,41 +1,19 @@
 use std::fmt;
+use std::net::Ipv4Addr;
 
 use crate::curl;
 use crate::result::MtcapError;
 
-const IPV4_LENGTH: usize = 4;
-
-#[derive(Clone)]
-struct Ipv4 {
-    digits: [u8; IPV4_LENGTH],
-}
-
-impl fmt::Display for Ipv4 {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(
-            f,
-            "{}.{}.{}.{}",
-            self.digits[0], self.digits[1], self.digits[2], self.digits[3],
-        )
-    }
-}
-
-impl Ipv4 {
-    fn new(ip: [u8; IPV4_LENGTH]) -> Self {
-        Self { digits: ip }
-    }
-}
-
 pub struct Gateway {
-    ip: Ipv4,
+    ip: Ipv4Addr,
     username: String,
     password: String,
 }
 
 impl Gateway {
-    pub fn new(ip: [u8; IPV4_LENGTH], username: String, password: String) -> Self {
+    pub fn new(ip: Ipv4Addr, username: String, password: String) -> Self {
         Self {
-            ip: Ipv4::new(ip),
+            ip,
             username,
             password,
         }
@@ -43,12 +21,12 @@ impl Gateway {
 }
 
 pub struct Token {
-    ip: Ipv4,
+    ip: Ipv4Addr,
     token: String,
 }
 
 impl Token {
-    fn new(ip: Ipv4, token: String) -> Self {
+    fn new(ip: Ipv4Addr, token: String) -> Self {
         Self { ip, token }
     }
 }
@@ -62,7 +40,7 @@ pub fn login(gateway: &Gateway) -> Result<Token, MtcapError> {
     let json = json::parse(&response)?;
     let token_string = json["result"]["token"].to_string();
 
-    let token = Token::new(gateway.ip.clone(), token_string);
+    let token = Token::new(gateway.ip, token_string);
 
     Ok(token)
 }

--- a/src/devices.rs
+++ b/src/devices.rs
@@ -42,7 +42,7 @@ impl Device {
     }
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Eui {
     digits: [u8; EUI_LENGTH],
 }


### PR DESCRIPTION
No need to define something that is already defined in `std`!